### PR TITLE
Add target char frequency syscalls

### DIFF
--- a/xv6-riscv/Makefile
+++ b/xv6-riscv/Makefile
@@ -137,8 +137,10 @@ UPROGS=\
 	$U/_stressfs\
 	$U/_usertests\
 	$U/_grind\
-	$U/_wc\
-	$U/_zombie\
+        $U/_wc\
+        $U/_zombie\
+        $U/_target\
+        $U/_freq\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/xv6-riscv/kernel/syscall.c
+++ b/xv6-riscv/kernel/syscall.c
@@ -101,6 +101,8 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_setTargetChar(void);
+extern uint64 sys_countTargetFreq(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -124,8 +126,10 @@ static uint64 (*syscalls[])(void) = {
 [SYS_mknod]   sys_mknod,
 [SYS_unlink]  sys_unlink,
 [SYS_link]    sys_link,
-[SYS_mkdir]   sys_mkdir,
-[SYS_close]   sys_close,
+  [SYS_mkdir]   sys_mkdir,
+  [SYS_close]   sys_close,
+  [SYS_setTargetChar] sys_setTargetChar,
+  [SYS_countTargetFreq] sys_countTargetFreq,
 };
 
 void

--- a/xv6-riscv/kernel/syscall.h
+++ b/xv6-riscv/kernel/syscall.h
@@ -20,3 +20,7 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+
+// custom syscalls
+#define SYS_setTargetChar 22
+#define SYS_countTargetFreq 23

--- a/xv6-riscv/kernel/sysproc.c
+++ b/xv6-riscv/kernel/sysproc.c
@@ -91,3 +91,36 @@ sys_uptime(void)
   release(&tickslock);
   return xticks;
 }
+
+// new global variable to hold target character
+static char target_char = '\0';
+
+// system call: setTargetChar
+uint64
+sys_setTargetChar(void)
+{
+  int c;
+  // fetch argument as int; treat lower byte as character
+  argint(0, &c);
+  target_char = (char)c;
+  return 0;
+}
+
+// system call: countTargetFreq
+uint64
+sys_countTargetFreq(void)
+{
+  uint64 ustr; // user space address
+  argaddr(0, &ustr);
+
+  // copy user string into kernel buffer while counting
+  char buf[256];
+  int len = fetchstr(ustr, buf, sizeof(buf));
+  if(len < 0)
+    return -1;
+  int count = 0;
+  for(int i = 0; buf[i]; i++)
+    if(buf[i] == target_char)
+      count++;
+  return count;
+}

--- a/xv6-riscv/user/freq.c
+++ b/xv6-riscv/user/freq.c
@@ -1,0 +1,20 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[])
+{
+  if(argc != 2){
+    fprintf(2, "usage: freq string\n");
+    exit(1);
+  }
+  int count = countTargetFreq(argv[1]);
+  if(count < 0){
+    fprintf(2, "frequency count failed\n");
+    exit(1);
+  }
+  printf("Found %d occurrences of target\n", count);
+  exit(0);
+}
+

--- a/xv6-riscv/user/target.c
+++ b/xv6-riscv/user/target.c
@@ -1,0 +1,20 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[])
+{
+  if(argc != 2){
+    fprintf(2, "usage: target char\n");
+    exit(1);
+  }
+  char c = argv[1][0];
+  if(setTargetChar(c) < 0){
+    fprintf(2, "failed to set target\n");
+    exit(1);
+  }
+  printf("Target character set to '%c'\n", c);
+  exit(0);
+}
+

--- a/xv6-riscv/user/user.h
+++ b/xv6-riscv/user/user.h
@@ -22,6 +22,8 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int setTargetChar(char);
+int countTargetFreq(const char*);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/xv6-riscv/user/usys.pl
+++ b/xv6-riscv/user/usys.pl
@@ -36,3 +36,5 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("setTargetChar");
+entry("countTargetFreq");


### PR DESCRIPTION
## Summary
- add SYS_setTargetChar and SYS_countTargetFreq system calls
- implement kernel handlers storing target char and counting occurrences
- expose the syscalls to user space
- provide `target` and `freq` user utilities
- register utilities in Makefile
- fix arg* usages in syscall handlers

## Testing
- `make -C xv6-riscv user/usys.S` *(fails: Couldn't find a riscv64 version of GCC/binutils)*
- `make -C xv6-riscv kernel` *(fails: Couldn't find a riscv64 version of GCC/binutils)*

------
https://chatgpt.com/codex/tasks/task_e_6850ebf079908327960e1b670e113846