### PR TITLE
Add target character frequency syscalls and commands

### DIFF
--- a/xv6-riscv/Makefile
+++ b/xv6-riscv/Makefile
@@ -136,9 +136,11 @@ UPROGS=\
 	$U/_sh\
 	$U/_stressfs\
 	$U/_usertests\
-	$U/_grind\
-	$U/_wc\
-	$U/_zombie\
+        $U/_grind\
+        $U/_wc\
+        $U/_zombie\
+        $U/_target\
+        $U/_freq\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/xv6-riscv/kernel/syscall.c
+++ b/xv6-riscv/kernel/syscall.c
@@ -101,6 +101,8 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_setTargetChar(void);
+extern uint64 sys_countTargetFreq(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +128,8 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_setTargetChar] sys_setTargetChar,
+[SYS_countTargetFreq] sys_countTargetFreq,
 };
 
 void

--- a/xv6-riscv/kernel/syscall.h
+++ b/xv6-riscv/kernel/syscall.h
@@ -20,3 +20,5 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_setTargetChar 22
+#define SYS_countTargetFreq 23

--- a/xv6-riscv/kernel/sysproc.c
+++ b/xv6-riscv/kernel/sysproc.c
@@ -6,6 +6,8 @@
 #include "spinlock.h"
 #include "proc.h"
 
+static char target_char = '\0';
+
 uint64
 sys_exit(void)
 {
@@ -90,4 +92,26 @@ sys_uptime(void)
   xticks = ticks;
   release(&tickslock);
   return xticks;
+}
+
+uint64
+sys_setTargetChar(void)
+{
+  int c;
+  argint(0, &c);
+  target_char = (char)c;
+  return 0;
+}
+
+uint64
+sys_countTargetFreq(void)
+{
+  char str[PGSIZE];
+  if(argstr(0, str, PGSIZE) < 0)
+    return -1;
+  int count = 0;
+  for(int i = 0; str[i]; i++)
+    if(str[i] == target_char)
+      count++;
+  return count;
 }

--- a/xv6-riscv/user/freq.c
+++ b/xv6-riscv/user/freq.c
@@ -1,0 +1,15 @@
+#include "kernel/types.h"
+#include "user/user.h"
+#include "kernel/stat.h"
+
+int
+main(int argc, char *argv[])
+{
+  if(argc != 2){
+    fprintf(2, "usage: freq <string>\n");
+    exit(1);
+  }
+  int count = countTargetFreq(argv[1]);
+  printf("Found %d occurrences of target\n", count);
+  exit(0);
+}

--- a/xv6-riscv/user/target.c
+++ b/xv6-riscv/user/target.c
@@ -1,0 +1,16 @@
+#include "kernel/types.h"
+#include "user/user.h"
+#include "kernel/stat.h"
+
+int
+main(int argc, char *argv[])
+{
+  if(argc != 2 || strlen(argv[1]) != 1){
+    fprintf(2, "usage: target <char>\n");
+    exit(1);
+  }
+  char c = argv[1][0];
+  setTargetChar(c);
+  printf("Target character set to '%c'\n", c);
+  exit(0);
+}

--- a/xv6-riscv/user/user.h
+++ b/xv6-riscv/user/user.h
@@ -22,6 +22,8 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int setTargetChar(char);
+int countTargetFreq(const char*);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/xv6-riscv/user/usys.pl
+++ b/xv6-riscv/user/usys.pl
@@ -36,3 +36,5 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("setTargetChar");
+entry("countTargetFreq");


### PR DESCRIPTION
## Summary
- introduce new syscalls `setTargetChar` and `countTargetFreq`
- store a target char in kernel space and count its occurrences
- add user commands `target` and `freq`
- generate syscall stubs and update user headers
- include programs in the build

## Testing
- `make` *(fails: Couldn't find a riscv64 version of GCC/binutils)*

------
https://chatgpt.com/codex/tasks/task_e_6851213a82948327b2e35ed2e2626cd9