### PR TITLE
Add countFreq syscall and freqall command

### DIFF
--- a/xv6-riscv/Makefile
+++ b/xv6-riscv/Makefile
@@ -136,9 +136,10 @@ UPROGS=\
 	$U/_sh\
 	$U/_stressfs\
 	$U/_usertests\
-	$U/_grind\
-	$U/_wc\
-	$U/_zombie\
+        $U/_grind\
+        $U/_wc\
+        $U/_zombie\
+        $U/_freqall\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/xv6-riscv/kernel/freq.h
+++ b/xv6-riscv/kernel/freq.h
@@ -1,0 +1,8 @@
+#ifndef FREQ_H
+#define FREQ_H
+
+struct freq_array {
+  int counts[128];
+};
+
+#endif // FREQ_H

--- a/xv6-riscv/kernel/syscall.c
+++ b/xv6-riscv/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_countFreq(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_countFreq] sys_countFreq,
 };
 
 void

--- a/xv6-riscv/kernel/syscall.h
+++ b/xv6-riscv/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_countFreq 22

--- a/xv6-riscv/kernel/sysproc.c
+++ b/xv6-riscv/kernel/sysproc.c
@@ -91,3 +91,29 @@ sys_uptime(void)
   release(&tickslock);
   return xticks;
 }
+
+#include "freq.h"
+
+uint64
+sys_countFreq(void)
+{
+  uint64 arr_addr;
+  struct freq_array freq;
+  char buf[256];
+  if(argstr(0, buf, sizeof(buf)) < 0)
+    return -1;
+  argaddr(1, &arr_addr);
+
+  memset(freq.counts, 0, sizeof(freq.counts));
+  for(int i = 0; buf[i]; i++){
+    unsigned char c = buf[i];
+    if(c < 128)
+      freq.counts[c]++;
+  }
+
+  printf("Target string %s (kernel space)\n", buf);
+
+  if(copyout(myproc()->pagetable, arr_addr, (char*)&freq, sizeof(freq)) < 0)
+    return -1;
+  return 0;
+}

--- a/xv6-riscv/user/freqall.c
+++ b/xv6-riscv/user/freqall.c
@@ -1,0 +1,30 @@
+#include "kernel/types.h"
+#include "kernel/freq.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[])
+{
+  if(argc < 2){
+    printf("usage: freqall string\n");
+    exit(1);
+  }
+
+  struct freq_array arr;
+  if(countFreq(argv[1], &arr) < 0){
+    printf("countFreq syscall failed\n");
+    exit(1);
+  }
+  int first = 1;
+  for(int i = 0; i < 128; i++){
+    if(arr.counts[i] > 0){
+      if(first){
+        printf("%c: %d (user space)\n", (char)i, arr.counts[i]);
+        first = 0;
+      } else {
+        printf("%c: %d\n", (char)i, arr.counts[i]);
+      }
+    }
+  }
+  exit(0);
+}

--- a/xv6-riscv/user/user.h
+++ b/xv6-riscv/user/user.h
@@ -1,4 +1,5 @@
 struct stat;
+struct freq_array;
 
 // system calls
 int fork(void);
@@ -22,6 +23,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int countFreq(char*, struct freq_array*);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/xv6-riscv/user/usys.pl
+++ b/xv6-riscv/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("countFreq");


### PR DESCRIPTION
## Summary
- implement `countFreq` syscall that counts ASCII frequency of a string
- expose the syscall to userland and add a `freqall` user command
- refine `freqall` output formatting
- add header guard for shared struct
- fetch string argument with `argstr`

## Testing
- ❌ `make fs.img` (failed: riscv64 toolchain missing)

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6851346b00208327a7a1c78698cd8981